### PR TITLE
OBIS validate for F.F did not pass

### DIFF
--- a/components/iec62056/__init__.py
+++ b/components/iec62056/__init__.py
@@ -32,7 +32,7 @@ def validate_obis(value):
     # F.35
     # 0.2.2
     # 0-0:1.0.0*102
-    rx = r"(\d+-\d+\:){,1}[\dA-F]+\.\d+(.\d+){,1}(\*\d+){,1}"
+    rx = r"(\d+-\d+\:){,1}[\dA-F]+\.[\dA-F]+(.\d+){,1}(\*\d+){,1}"
 
     m = re.fullmatch(rx, value)
     if m is None:


### PR DESCRIPTION
Accept A-F on 2nd OBIS position

Suggestion for the documentation:
  - platform: iec62056
    obis: **"**36.7**"**
The quotes would have saved me a couple of evenings to figure out that there is a underlying conversion to text but for decimal it did not happen. 