### PR TITLE
convert ',' to '.', allow multiple instances and ESP-IDF compatibility, added triggers

### DIFF
--- a/components/iec62056/__init__.py
+++ b/components/iec62056/__init__.py
@@ -19,6 +19,7 @@ CONF_RETRY_COUNTER_MAX = "retry_counter_max"
 CONF_RETRY_DELAY = "retry_delay"
 CONF_MODE_D = "mode_d"  # protocol mode D
 CONF_BAUD_RATE_MAX = "baud_rate_max"
+CONF_CONVERT_COMMA = "convert_comma"
 
 iec62056_ns = cg.esphome_ns.namespace("iec62056")
 IEC62056Component = iec62056_ns.class_(
@@ -59,6 +60,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_UPDATE_INTERVAL, default="15min"): cv.update_interval,
             cv.Optional(CONF_BAUD_RATE_MAX, default=9600): validate_baud_rate,
             cv.Optional(CONF_BATTERY_METER, default=False): cv.boolean,
+            cv.Optional(CONF_CONVERT_COMMA, default=False): cv.boolean,
             cv.Optional(
                 CONF_RECEIVE_TIMEOUT, default="3s"
             ): cv.positive_time_period_milliseconds,
@@ -90,6 +92,9 @@ async def to_code(config):
 
     if CONF_BATTERY_METER in config:
         cg.add(var.set_battery_meter(config[CONF_BATTERY_METER]))
+
+    if CONF_CONVERT_COMMA in config:
+        cg.add(var.set_convert_comma(config[CONF_CONVERT_COMMA]))
 
     if CONF_RETRY_COUNTER_MAX in config:
         cg.add(var.set_max_retry_counter(config[CONF_RETRY_COUNTER_MAX]))

--- a/components/iec62056/__init__.py
+++ b/components/iec62056/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
 from esphome import automation
 
 CODEOWNERS = ["@aquaticus"]
+MULTI_CONF = True
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["sensor", "text_sensor", "switch", "binary_sensor"]

--- a/components/iec62056/__init__.py
+++ b/components/iec62056/__init__.py
@@ -6,7 +6,9 @@ from esphome.const import (
     CONF_ID,
     CONF_RECEIVE_TIMEOUT,
     CONF_UPDATE_INTERVAL,
+    CONF_TRIGGER_ID
 )
+from esphome import automation
 
 CODEOWNERS = ["@aquaticus"]
 
@@ -20,12 +22,20 @@ CONF_RETRY_DELAY = "retry_delay"
 CONF_MODE_D = "mode_d"  # protocol mode D
 CONF_BAUD_RATE_MAX = "baud_rate_max"
 CONF_CONVERT_COMMA = "convert_comma"
+CONF_ON_TIMEOUT = "on_timeout"
+CONF_ON_WAIT_NEXT_READOUT = "on_wait_next_readout"
 
 iec62056_ns = cg.esphome_ns.namespace("iec62056")
 IEC62056Component = iec62056_ns.class_(
     "IEC62056Component", cg.Component, uart.UARTDevice
 )
 
+Iec62056OTimeoutTrigger = iec62056_ns.class_(
+    "Iec62056OTimeoutTrigger", automation.Trigger
+)
+Iec62056OWaitNextReadoutTrigger = iec62056_ns.class_(
+    "Iec62056OWaitNextReadoutTrigger", automation.Trigger
+)
 
 def validate_obis(value):
     # match, e.g.
@@ -69,6 +79,20 @@ CONFIG_SCHEMA = cv.All(
                 CONF_RETRY_DELAY, default="15s"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_MODE_D, default=False): cv.boolean,
+            cv.Optional(CONF_ON_TIMEOUT): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        Iec62056OTimeoutTrigger
+                    ),
+                }
+            ),
+            cv.Optional(CONF_ON_WAIT_NEXT_READOUT): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        Iec62056OWaitNextReadoutTrigger
+                    ),
+                }
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -104,3 +128,11 @@ async def to_code(config):
 
     if CONF_MODE_D in config:
         cg.add(var.set_mode_d(config[CONF_MODE_D]))
+
+    for conf in config.get(CONF_ON_TIMEOUT, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+
+    for conf in config.get(CONF_ON_WAIT_NEXT_READOUT, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)

--- a/components/iec62056/iec62056.cpp
+++ b/components/iec62056/iec62056.cpp
@@ -801,6 +801,7 @@ void IEC62056Component::retry_or_sleep_() {
     set_next_state_(MODE_D_WAIT);
   } else if (retry_counter_ >= max_retries_) {
     ESP_LOGD(TAG, "Exceeded retry counter.");
+    this->on_timeout_callback_.call();
     wait_next_readout_();
   } else {
     retry_counter_inc_();
@@ -825,6 +826,8 @@ void IEC62056Component::trigger_readout() {
 }
 
 void IEC62056Component::wait_next_readout_() {
+  this->on_wait_next_readout_callback_.call();
+
   if (force_mode_d_) {
     set_next_state_(MODE_D_WAIT);
     return;

--- a/components/iec62056/iec62056.h
+++ b/components/iec62056/iec62056.h
@@ -59,6 +59,9 @@ class IEC62056Component : public Component, public uart::UARTDevice {
   /// Set flag indicating battery operated meter.
   /// @param flag @c true for battery operated meter, otherwise @c false.
   void set_battery_meter(bool flag) { battery_meter_ = flag; }
+  /// Set flag indicating to convert commas in the values.
+  /// @param flag @c true to convert commas, else @c false.
+  void set_convert_comma(bool flag) { convert_comma_ = flag; }
   /// @brief Called when switch state changed. Begins readout.
   void trigger_readout();
   void set_mode_d(bool flag) { force_mode_d_ = flag; }
@@ -161,6 +164,8 @@ class IEC62056Component : public Component, public uart::UARTDevice {
   uint32_t retry_delay_{10000};
   /// @brief Flag indicating battery meter.
   bool battery_meter_;
+  /// @brief Flag to convert for commas in values.
+  bool convert_comma_;
   /// @brief The current state of the state machine.
   CommState state_;
   /// @brief Timestamp, the last transmission from the meter.

--- a/components/iec62056/iec62056uart.h
+++ b/components/iec62056/iec62056uart.h
@@ -170,7 +170,7 @@ class IEC62056UART final : public uart::IDFUARTComponent {
       this->has_peek_ = false;
     }
     if (length_to_read > 0)
-      uart_read_bytes(this->iuart_num_, data, length_to_read, 20 / portTICK_RATE_MS);
+      uart_read_bytes(this->iuart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
     xSemaphoreGive(this->ilock_);
 
     return true;


### PR DESCRIPTION
# SCR compatibility
I have multiple gas meters that use SCR as the electrical interface. This needs some additions to the code:

## Convert ',' to '.' (5a7a64c8748d56c4b9db3beb01f7706806904a7b)
Some gas meters send an ',' as decimal point, this option does convert that.

## ESP-IDF (1b580a1840e74dc659a68d9ba76b9893787c30ce) and multiple instances (81b33ba39974dc2d1e8fcebae1e6d7a83800feb4)
Allow multiple instances and the usage with ESP-IDF as framework. An ESP32 has three UARTs, no need to artificially limit the iec62056 component to one single instance.

## new triggers (7c5fea1354bacb1fa45bce9741503dc18384d034)
Added triggers for `on_timeout` and `on_wait_next_readout`.

# Sample YAML to read the gas meter
```yaml
uart:
  - id: uart_bus1
    tx_pin: 14
    rx_pin: 39
    baud_rate: 300
    data_bits: 7
    parity: EVEN
    stop_bits: 1
    rx_buffer_size: 1024

iec62056:
  - id: gasmeter1
    uart_id: uart_bus1
    update_interval: never
    baud_rate_max: 300
    battery_meter: False
    receive_timeout: 5s
    convert_comma: true
    retry_counter_max: 0

    on_wait_next_readout:
      - delay: 1s
      - switch.turn_on: overrideTX1
      - switch.turn_off: readoutTrigger1
      
switch:
  - platform: gpio
    pin: GPIO5
    id: overrideTX1
    internal: true
    restore_mode: ALWAYS_ON

  - platform: iec62056
    name: 'Readout Trigger 1'
    iec62056_id: gasmeter1
    id: readoutTrigger1
    internal: true

interval:
  - interval: 1min
    then:
      - switch.turn_off: overrideTX1
      - delay: 5s
      - switch.turn_on:  readoutTrigger1
```

# Schematics
SCR works by modulating the *voltage* (5V) to send a request to the meter, which in turn modulates the *current* (4mA/8mA) to send data back. This is solved by an transistor to send and an Op-Amp as comparator for receiving. 

I ran into a problem with the long term stability of the communication: after about a day the meter went into a strange mode and didn't respond anymore. The solution was to regularily cut the power to the meter, this is the circuit with the second transistor (`TX override`) and the additional trigger with the interval. This works now for more than a month.

![IMG_20250323_002209_420](https://github.com/user-attachments/assets/6245ca1b-8040-4ce0-9340-b554e2746cfe)